### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:11-jdk-slim
 ARG jar
 COPY $jar /opt/censusjobsvc.jar
 ENV JAVA_OPTS=""
-ENTRYPOINT [ "sh", "-c", "java -jar /opt/censusjobsvc.jar" ]
+ENTRYPOINT [ "java",  "-jar", "/opt/censusjobsvc.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM openjdk:11-jdk-slim
 ARG jar
-VOLUME /tmp
 COPY $jar censusjobsvc.jar
 ENV JAVA_OPTS=""
 ENTRYPOINT [ "sh", "-c", "java -jar /censusjobsvc.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:11-jdk-slim
 ARG jar
-COPY $jar censusjobsvc.jar
+COPY $jar /opt/censusjobsvc.jar
 ENV JAVA_OPTS=""
-ENTRYPOINT [ "sh", "-c", "java -jar /censusjobsvc.jar" ]
+ENTRYPOINT [ "sh", "-c", "java -jar /opt/censusjobsvc.jar" ]


### PR DESCRIPTION
Three improvements to the Docker file.

The _exec_ form of `ENTRYPOINT` should be used to ensure that there's just a Java process running rather than a shell process that launches the Java process. This also ensures that the Java process will be sent any Unix signals rather than the shell process. See https://docs.docker.com/engine/reference/builder/#entrypoint