### PR TITLE
FWMT-712 get case id directly instead of from additional property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ springBoot {
 }
 
 dependencies {
-    compile("uk.gov.ons.fwmt:fwmt-census-canonical:1.0.1-SNAPSHOT")
+    compile("uk.gov.ons.fwmt:fwmt-census-canonical:1.0.2-SNAPSHOT")
     compile("uk.gov.ons.fwmt:fwmt-census-common:1.0.1-SNAPSHOT")
 
     compile('org.springframework.boot:spring-boot-starter')

--- a/src/main/java/uk/gov/ons/fwmt/census/jobservice/comet/dto/ModelCase.java
+++ b/src/main/java/uk/gov/ons/fwmt/census/jobservice/comet/dto/ModelCase.java
@@ -8,11 +8,12 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 
 @Data
 @NoArgsConstructor
 public class ModelCase {
-  private String id = null;
+  private UUID id = null;
   private String reference = null;
   private String caseType = null;
   private StateEnum state = null;

--- a/src/main/java/uk/gov/ons/fwmt/census/jobservice/converter/impl/CCSConverter.java
+++ b/src/main/java/uk/gov/ons/fwmt/census/jobservice/converter/impl/CCSConverter.java
@@ -22,7 +22,7 @@ public class CCSConverter implements CometConverter {
   public ModelCase convert(CreateFieldWorkerJobRequest ingest) {
     ModelCase modelCase = new ModelCase();
     Instant instant = Instant.now();
-    modelCase.setId(ingest.getAdditionalProperties().get("caseId"));
+    modelCase.setId(ingest.getCaseId());
     modelCase.setReference(ingest.getJobIdentity());
     modelCase.setCaseType(CASE_TYPE_CCS);
     modelCase.setState(OPEN);

--- a/src/main/java/uk/gov/ons/fwmt/census/jobservice/converter/impl/CEConverter.java
+++ b/src/main/java/uk/gov/ons/fwmt/census/jobservice/converter/impl/CEConverter.java
@@ -23,7 +23,7 @@ public class CEConverter implements CometConverter {
   public ModelCase convert(CreateFieldWorkerJobRequest ingest) {
     ModelCase modelCase = new ModelCase();
     Instant instant = Instant.now();
-    modelCase.setId(ingest.getAdditionalProperties().get("caseId"));
+    modelCase.setId(ingest.getCaseId());
     modelCase.setReference(ingest.getJobIdentity());
     modelCase.setCaseType(CASE_TYPE_CE);
     modelCase.setState(OPEN);

--- a/src/main/java/uk/gov/ons/fwmt/census/jobservice/converter/impl/HouseholdConverter.java
+++ b/src/main/java/uk/gov/ons/fwmt/census/jobservice/converter/impl/HouseholdConverter.java
@@ -22,7 +22,7 @@ public class HouseholdConverter implements CometConverter {
   public ModelCase convert(CreateFieldWorkerJobRequest ingest) {
     ModelCase modelCase = new ModelCase();
     Instant instant = Instant.now();
-    modelCase.setId(ingest.getAdditionalProperties().get("caseId"));
+    modelCase.setId(ingest.getCaseId());
     modelCase.setReference(ingest.getJobIdentity());
     modelCase.setCaseType(CASE_TYPE_HH); 
     modelCase.setState(OPEN);

--- a/src/test/java/uk/gov/ons/fwmt/census/jobservice/rest/client/CometRestClientTest.java
+++ b/src/test/java/uk/gov/ons/fwmt/census/jobservice/rest/client/CometRestClientTest.java
@@ -1,0 +1,39 @@
+package uk.gov.ons.fwmt.census.jobservice.rest.client;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.ons.fwmt.census.jobservice.comet.dto.Address;
+import uk.gov.ons.fwmt.census.jobservice.comet.dto.Contact;
+import uk.gov.ons.fwmt.census.jobservice.comet.dto.ModelCase;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CometRestClientTest {
+
+  @Mock
+  private RestTemplate restTemplate;
+
+  @Test
+  public void sendCreateJobRequestTest() {
+
+    CometRestClient cometRestClient = new CometRestClient(restTemplate, "bla/", "test/");
+    ModelCase modelCase = new ModelCase();
+    modelCase.setId(UUID.fromString("2ff1b10e-f841-43d4-a129-7269ac239b61"));
+    modelCase.setAddress(new Address());
+    modelCase.setContact(new Contact());
+    modelCase.setReference("qwertyu");
+    HttpEntity<ModelCase> body = new HttpEntity<>(modelCase);
+
+    cometRestClient.sendCreateJobRequest(modelCase);
+
+    verify(restTemplate).exchange("bla/test/2ff1b10e-f841-43d4-a129-7269ac239b61", HttpMethod.PUT, body, Void.class);
+  }
+}


### PR DESCRIPTION
case id has been added to CreateFieldWorkerJobRequest so no longer needs to be retrieved through an additional property